### PR TITLE
Avoid CLI errors when trying to view subcommand help

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "git-tide"
-version = "0.2.1"
+version = "0.2.2"
 description = "CLI for automated gitflow-style branching"
 authors = [
     {name="Chad Dombrova"},

--- a/src/tide/cli.py
+++ b/src/tide/cli.py
@@ -4,6 +4,7 @@ import time
 import os
 import subprocess
 import re
+import sys
 from pathlib import Path
 
 from .core import (
@@ -75,8 +76,11 @@ def get_runtime() -> Runtime:
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option("--config", "-c", "config_path", metavar="CONFIG", type=str)
 @click.option("--verbose", "-v", is_flag=True, default=False)
-def cli(config_path: str, verbose: bool) -> None:
-    set_config(load_config(config_path, verbose))
+@click.pass_context
+def cli(ctx: click.Context, config_path: str, verbose: bool) -> None:
+    args = sys.argv[1:]
+    if not any(flag in args for flag in ctx.help_option_names):
+        set_config(load_config(config_path, verbose))
 
 
 @cli.command()
@@ -331,7 +335,7 @@ def projects(modified: bool) -> None:
     """
     List project paths within the repo.
 
-    A project is a folder with a pyproject.toml file with a `tool.commitizen` section.
+    A project is a folder with a pyproject.toml file with a `tool.tide` section.
     """
     if modified:
         runtime = get_runtime()
@@ -352,7 +356,7 @@ def projects(modified: bool) -> None:
     "--branch",
     default=None,
     help=(
-        "The release branch to use to determine the next version. "
+        "The release branch to use to determine the version release phase. "
         "Defaults to the current branch."
     ),
 )
@@ -362,7 +366,8 @@ def projects(modified: bool) -> None:
     show_default=True,
     help="The git remote to use to when determining the next version.",
 )
-@click.option("--next", "-n", is_flag=True, default=False)
+@click.option("--next", "-n", is_flag=True, default=False,
+    help="Whether to calculate the next version instead of returning the latest tag ")
 @click.option("--as-tag", "-t", is_flag=True, default=False)
 @click.option(
     "--path",


### PR DESCRIPTION
Small adjustment that makes it possible to run `tide <command> --help` without requiring a config.

Prior to this, it was impossible to explore the CLI surface area unless you were operating in a repository that already included a `tide` configuration, rendering the `tide init` command effectively unusable.

For example, in a folder with no `pyproject.toml`:
```
tide init --help
Error: No pyproject.toml found
```

Or, in a Python project without an existing `tool.tide` config section:
```
tide init --help
Error: 'tool.tide' section missing: /path/to/pyproject.toml
``