### PR TITLE
Move `next-version` to its own command, add `--at-ref` to `version` command

### DIFF
--- a/src/tide/cli.py
+++ b/src/tide/cli.py
@@ -372,7 +372,7 @@ def projects(modified: bool) -> None:
 @click.option(
     "--path",
     default=".",
-    type=click.Path(exists=True, file_okay=False),
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
     show_default=True,
     help="Folder within the repository. A pyproject.toml should reside in the "
     "specified directory",
@@ -381,15 +381,15 @@ def version(
     as_tag: bool,
     at_ref: str | None,
     branch: str | None,
-    path: str,
+    path: Path,
 ) -> None:
     """
     Get the current project version
     """
-    project_name = get_project_name(Path(path))
+    project_name = get_project_name(path)
     if project_name is None:
         raise click.ClickException(
-            f"Could not determine the project name at {path}. "
+            f"Could not determine the project name at {path.absolute()}. "
             "Ensure that the folder has a pyproject.toml file "
             "with project.name or tool.tide.project defined"
         )
@@ -442,7 +442,7 @@ def version(
 @click.option(
     "--path",
     default=".",
-    type=click.Path(exists=True, file_okay=False),
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
     show_default=True,
     help="Folder within the repository. A pyproject.toml should reside in the "
     "specified directory",
@@ -451,15 +451,15 @@ def next_version(
     branch: str | None,
     remote: str,
     as_tag: bool,
-    path: str,
+    path: Path,
 ) -> None:
     """
     Get the next project version
     """
-    project_name = get_project_name(Path(path))
+    project_name = get_project_name(path)
     if project_name is None:
         raise click.ClickException(
-            f"Could not determine the project name at {path}. "
+            f"Could not determine the project name at {path.absolute()}. "
             "Ensure that the folder has a pyproject.toml file "
             "with project.name or tool.tide.project defined"
         )

--- a/src/tide/cli.py
+++ b/src/tide/cli.py
@@ -11,6 +11,7 @@ from .core import (
     is_url,
     get_next_version,
     get_current_version,
+    get_version_at_ref,
     get_modified_projects,
     get_project_name,
     get_projects,
@@ -352,6 +353,77 @@ def projects(modified: bool) -> None:
 
 
 @cli.command
+@click.option("--as-tag", "-t", is_flag=True, default=False)
+@click.option(
+    "--at-ref",
+    default=None,
+    metavar="REF",
+    help="Git ref (commit SHA, branch, tag, etc.) to query version at. "
+    "Only existing tags at this ref will be considered.",
+)
+@click.option(
+    "--branch",
+    default=None,
+    metavar="BRANCH",
+    help="Release branch name to filter version tags by release phase. "
+    "Only applies when --at-ref is specified. "
+    "Examples: develop (alpha), staging (rc), master (stable).",
+)
+@click.option(
+    "--path",
+    default=".",
+    type=click.Path(exists=True, file_okay=False),
+    show_default=True,
+    help="Folder within the repository. A pyproject.toml should reside in the "
+    "specified directory",
+)
+def version(
+    as_tag: bool,
+    at_ref: str | None,
+    branch: str | None,
+    path: str,
+) -> None:
+    """
+    Get the current project version
+    """
+    project_name = get_project_name(Path(path))
+    if project_name is None:
+        raise click.ClickException(
+            f"Could not determine the project name at {path}. "
+            "Ensure that the folder has a pyproject.toml file "
+            "with project.name or tool.tide.project defined"
+        )
+
+    if branch and not at_ref:
+        raise click.ClickException(
+            "--branch can only be used with --at-ref"
+        )
+
+    if at_ref:
+        release_id = None
+        if branch:
+            if branch not in CONFIG.branch_to_release_id:
+                raise click.ClickException(
+                    f"Unknown branch '{branch}'. Must be one of: {', '.join(CONFIG.branches)}"
+                )
+            release_id = CONFIG.branch_to_release_id[branch]
+
+        click.echo(
+            get_version_at_ref(
+                CONFIG,
+                project_name=project_name,
+                ref=at_ref,
+                as_tag=as_tag,
+                release_id=release_id,
+            )
+        )
+    else:
+        click.echo(
+            get_current_version(CONFIG, project_name=project_name, as_tag=as_tag)
+        )
+
+
+@cli.command
 @click.option(
     "--branch",
     default=None,
@@ -364,10 +436,8 @@ def projects(modified: bool) -> None:
     "--remote",
     default="origin",
     show_default=True,
-    help="The git remote to use to when determining the next version.",
+    help="The git remote to use when determining the next version.",
 )
-@click.option("--next", "-n", is_flag=True, default=False,
-    help="Whether to calculate the next version instead of returning the latest tag ")
 @click.option("--as-tag", "-t", is_flag=True, default=False)
 @click.option(
     "--path",
@@ -377,15 +447,14 @@ def projects(modified: bool) -> None:
     help="Folder within the repository. A pyproject.toml should reside in the "
     "specified directory",
 )
-def version(
+def next_version(
     branch: str | None,
     remote: str,
-    next: bool,
     as_tag: bool,
     path: str,
 ) -> None:
     """
-    Get the project version
+    Get the next project version
     """
     project_name = get_project_name(Path(path))
     if project_name is None:
@@ -394,20 +463,15 @@ def version(
             "Ensure that the folder has a pyproject.toml file "
             "with project.name or tool.tide.project defined"
         )
-    if next:
-        if branch is None:
-            runtime = get_runtime()
-            branch = runtime.current_branch()
+    if branch is None:
+        runtime = get_runtime()
+        branch = runtime.current_branch()
 
-        click.echo(
-            get_next_version(
-                CONFIG, branch, project_name=project_name, remote=remote, as_tag=as_tag
-            )
+    click.echo(
+        get_next_version(
+            CONFIG, branch, project_name=project_name, remote=remote, as_tag=as_tag
         )
-    else:
-        click.echo(
-            get_current_version(CONFIG, project_name=project_name, as_tag=as_tag)
-        )
+    )
 
 
 def main() -> None:

--- a/src/tide/core.py
+++ b/src/tide/core.py
@@ -17,7 +17,7 @@ from functools import lru_cache
 from urllib.parse import urlparse, urlunparse
 from abc import abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Mapping, cast
+from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple, cast
 
 from .gitutils import (
     git,
@@ -682,21 +682,47 @@ def set_promotion_marker(remote: str, branch: str) -> None:
     git("push", remote, "refs/notes/*")
 
 
-def _get_cz_config(tag_format: str, project_name: str) -> commitizen.config.BaseConfig:
+class CommitizenContext(NamedTuple):
+    """Context for commitizen operations."""
+
+    config: commitizen.config.BaseConfig
+    provider: commitizen.providers.ScmProvider
+    scheme: commitizen.version_schemes.VersionProtocol
+
+
+def _init_commitizen_context(
+    config: Config, project_name: str
+) -> CommitizenContext:
+    """
+    Initialize commitizen configuration, provider, and scheme.
+
+    Args:
+        config: The tide configuration
+        project_name: The name of the project
+
+    Returns:
+        A CommitizenContext containing cz_config, provider, and scheme
+    """
     from commitizen.config.base_config import BaseConfig
     from commitizen.defaults import Settings
+    from commitizen.providers import ScmProvider
+    from commitizen.version_schemes import get_version_scheme
+
+    _patch_cz_run()
 
     cz_config = BaseConfig()
     cz_config.update(
         Settings(
             name="cz_conventional_commits",
-            tag_format=tag_format.replace("$project", project_name),
+            tag_format=config.tag_format.replace("$project", project_name),
             version_scheme="pep440",
             version_provider="scm",
             major_version_zero=False,
         )
     )
-    return cz_config
+    provider = ScmProvider(cz_config)
+    scheme = get_version_scheme(cz_config)
+    return CommitizenContext(cz_config, provider, scheme)
 
 
 def get_current_version(config: Config, project_name: str, as_tag: bool = False) -> str:
@@ -711,21 +737,15 @@ def get_current_version(config: Config, project_name: str, as_tag: bool = False)
     Returns:
         The current version or tag
     """
-    from commitizen.providers import ScmProvider
-    from commitizen.version_schemes import get_version_scheme
     from commitizen import bump
 
-    _patch_cz_run()
-
-    cz_config = _get_cz_config(config.tag_format, project_name)
-    provider = ScmProvider(cz_config)
-    scheme = get_version_scheme(cz_config)
-    current_version = provider.get_version()
+    cz_ctx = _init_commitizen_context(config, project_name)
+    current_version = cz_ctx.provider.get_version()
 
     tag_version = bump.normalize_tag(
         current_version,
-        tag_format=cz_config.settings["tag_format"] if as_tag else "$version",
-        scheme=scheme,
+        tag_format=cz_ctx.config.settings["tag_format"] if as_tag else "$version",
+        scheme=cz_ctx.scheme,
     )
 
     return tag_version
@@ -754,11 +774,8 @@ def get_next_version(
     Returns:
         The next version or tag to be created
     """
-    from commitizen.providers import ScmProvider
-    from commitizen.version_schemes import get_version_scheme, Increment
+    from commitizen.version_schemes import Increment
     from commitizen import bump
-
-    _patch_cz_run()
 
     try:
         release_id = config.branch_to_release_id[branch]
@@ -768,11 +785,8 @@ def get_next_version(
             f"Must be one of {', '.join(config.branches)}"
         )
 
-    cz_config = _get_cz_config(config.tag_format, project_name)
-
-    provider = ScmProvider(cz_config)
-    scheme = get_version_scheme(cz_config)
-    current_version = scheme(provider.get_version())
+    cz_ctx = _init_commitizen_context(config, project_name)
+    current_version = cz_ctx.scheme(cz_ctx.provider.get_version())
 
     if release_id != ReleaseID.stable:
         prerelease = release_id.value
@@ -792,7 +806,7 @@ def get_next_version(
     # Find the closest promotion note to the current branch
     pending_bump = is_pending_bump(
         config,
-        provider,
+        cz_ctx.provider,
         branch,
         remote,
         add_missing_promote_marker=not dry_run,
@@ -814,8 +828,8 @@ def get_next_version(
 
     return bump.normalize_tag(
         new_version,
-        tag_format=cz_config.settings["tag_format"] if as_tag else "$version",
-        scheme=scheme,
+        tag_format=cz_ctx.config.settings["tag_format"] if as_tag else "$version",
+        scheme=cz_ctx.scheme,
     )
 
 

--- a/src/tide/core.py
+++ b/src/tide/core.py
@@ -751,6 +751,80 @@ def get_current_version(config: Config, project_name: str, as_tag: bool = False)
     return tag_version
 
 
+def get_version_at_ref(
+    config: Config,
+    project_name: str,
+    ref: str,
+    as_tag: bool = False,
+    release_id: ReleaseID | None = None,
+) -> str:
+    """
+    Return the version at a specific git ref by looking up existing tags.
+
+    Args:
+        config: The tide configuration
+        project_name: The name of the project, used to look up tags
+        ref: The git ref (commit SHA, branch name, tag, etc.) to query
+        as_tag: Whether to format the version based on tool.tide.tag_format
+        release_id: Optional release ID to filter tags by release phase
+
+    Returns:
+        The version or tag at the specified ref
+
+    Raises:
+        click.ClickException: If a matching tag cannot be found at the given ref.
+    """
+    try:
+        tag_list = git("tag", "--points-at", ref, capture=True, quiet=True).splitlines()
+    except subprocess.CalledProcessError:
+        raise click.ClickException(f"Invalid git ref {ref!r}")
+    if not tag_list:
+        raise click.ClickException(f"No tags found at git ref {ref!r}")
+
+    cz_ctx = _init_commitizen_context(config, project_name)
+    matcher = cz_ctx.provider._tag_format_matcher()
+
+    version_tag_map = {version: tag for tag in tag_list if (version := matcher(tag))}
+    if not version_tag_map:
+        raise click.ClickException(
+            f"No version tags found for project {project_name!r} at git ref {ref!r}"
+        )
+
+    if release_id is not None:
+        phase_marker = release_id.prerelease_suffix()
+        if phase_marker is None:
+            phase_versions = [v for v in version_tag_map if v.pre is None]
+        else:
+            phase_versions = [
+                v for v in version_tag_map
+                if v.pre is not None and v.pre[0] == phase_marker
+            ]
+
+        # `version_tag_map` should already be filtered to the desired project, so we expect to
+        # find exactly one version matching the given release phase ID.
+        if len(phase_versions) != 1:
+            if phase_versions:
+                adjective = "Multiple"
+                suffix = f": {', '.join(version_tag_map[v] for v in phase_versions)}"
+            else:
+                adjective = "No"
+                suffix = ""
+            raise click.ClickException(
+                f"{adjective} tags found for project {project_name!r} and release phase "
+                f"{release_id.value!r} at git ref {ref!r}{suffix}"
+            )
+
+        matching_version = phase_versions[0]
+    else:
+        # If no release phase is specified, we just want the "latest" version.
+        matching_version = sorted(version_tag_map)[-1]
+
+    if as_tag:
+        return version_tag_map[matching_version]
+    else:
+        return str(matching_version)
+
+
 def get_next_version(
     config: Config,
     branch: str,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -413,6 +413,7 @@ def git_graph() -> str:
         "--format=format:%C(white)%s%C(reset) %C(dim white)- %C(auto)%d%C(reset)",
         "--all",
         "--decorate",
+        "--decorate-refs-exclude=refs/remotes/origin/HEAD",
         capture=True,
     )
 
@@ -535,6 +536,10 @@ def _tide(*args: str, capture: bool = False) -> str | subprocess.CompletedProces
         return output
     else:
         return subprocess.run(cmd, text=True, check=True)
+
+
+def get_version_at_ref(path: str, ref: str) -> str:
+    return _tide("version", "--path", path, "--at-ref", ref, capture=True)
 
 
 def gitlab_ci_local(job_name: str, runner_env: dict[str, str]):
@@ -895,6 +900,9 @@ def test_dev_cycle(setup_git_repo, monkeypatch, tmp_path_factory) -> None:
         run_autotag(env, remote_data)
 
     assert latest_tag("projectA-*") == "projectA-1.1.0b0"
+    assert get_version_at_ref("projectA", config.beta) == "1.1.0b0"
+    with pytest.raises(subprocess.CalledProcessError):
+        get_version_at_ref("projectB", config.beta)
 
     # -- promote
     tag_args = [
@@ -1026,6 +1034,10 @@ def test_dev_cycle(setup_git_repo, monkeypatch, tmp_path_factory) -> None:
     * initial state -  (tag: projectB-1.0.0, tag: projectA-1.0.0)
     """
     verify_git_graph(expected)
+
+    assert get_version_at_ref("projectA", f"{config.beta}^^") == "1.2.0b1"
+    with pytest.raises(subprocess.CalledProcessError):
+        assert get_version_at_ref("projectB", config.beta) == "1.1.0b0"
 
     # there are no changes for projectB, so the tag should remain the same
     assert latest_tag("projectB-*") == "projectB-1.1.0b0"


### PR DESCRIPTION
- Add the ability to query existing version tags from commits using `tide version --at-ref <GIT_REF>`
- Move the logic for determining the next version to a new `next-version` command