### PR TITLE
Add support for major bumps on breaking changes via conventional commits

### DIFF
--- a/src/tide/cli.py
+++ b/src/tide/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .core import (
     is_url,
+    ensure_breaking_change_allowed,
     get_next_version,
     get_current_version,
     get_version_at_ref,
@@ -210,6 +211,15 @@ def autotag(
         projects_and_paths = get_modified_projects(base_rev, verbose=CONFIG.verbose)
     if projects_and_paths:
         for project_folder, project_name in projects_and_paths:
+            # Breaking changes are only permitted on the most-experimental
+            # branch. Reject them here so they cannot enter the hotfix cascade.
+            ensure_breaking_change_allowed(
+                CONFIG,
+                branch,
+                project_name=project_name,
+                base_rev=base_rev,
+                project_path=project_folder,
+            )
             # Auto-tag
             tag = get_next_version(
                 CONFIG,
@@ -218,6 +228,7 @@ def autotag(
                 remote=remote,
                 as_tag=True,
                 dry_run=False,
+                project_path=project_folder,
             )
             # tag can be None if a branch has not yet received its first seed promotion.
             # for example: prior to beta being promoted to rc, there will not be any
@@ -465,9 +476,30 @@ def next_version(
         runtime = get_runtime()
         branch = runtime.current_branch()
 
+    # This is a read-only query, so warn (rather than error) if a breaking
+    # change is present on a branch where it is not permitted.
+    try:
+        base_rev: str | None = current_rev("HEAD^")
+    except subprocess.CalledProcessError:
+        base_rev = None
+    if base_rev is not None:
+        ensure_breaking_change_allowed(
+            CONFIG,
+            branch,
+            project_name=project_name,
+            base_rev=base_rev,
+            project_path=path,
+            raise_error=False,
+        )
+
     click.echo(
         get_next_version(
-            CONFIG, branch, project_name=project_name, remote=remote, as_tag=as_tag
+            CONFIG,
+            branch,
+            project_name=project_name,
+            remote=remote,
+            as_tag=as_tag,
+            project_path=path,
         )
     )
 

--- a/src/tide/core.py
+++ b/src/tide/core.py
@@ -547,7 +547,7 @@ def cz(*args: str, folder: str | Path | None = None) -> str:
     return output.strip()
 
 
-def is_pending_bump(
+def is_pending_minor_bump(
     config: Config,
     provider: commitizen.providers.ScmProvider,
     branch: str,
@@ -601,7 +601,7 @@ def is_pending_bump(
     all_tags = get_tags(end_rev=promotion_rev)
     for tag in all_tags:
         ver = matcher(tag)
-        # If we find a matching tag and that tag corresponds to our expected branch
+        # If we find a matching tag nd that tag corresponds to our expected branch
         # then promotion has already occurred.
         if ver is not None and prerelease_match(ver):
             return False
@@ -723,6 +723,157 @@ def _init_commitizen_context(config: Config, project_name: str) -> CommitizenCon
     return CommitizenContext(cz_config, provider, scheme)
 
 
+def has_breaking_change(
+    cz_ctx: CommitizenContext,
+    start_rev: str | None,
+    end_rev: str = "HEAD",
+    path: Path | str | None = None,
+) -> bool:
+    """
+    Return whether a breaking conventional commit exists in a commit range.
+
+    Only commitizen's ``MAJOR`` verdict is consumed here: the ``MINOR``/``PATCH``
+    increments implied by ``feat``/``fix`` commits are deliberately ignored,
+    because those are governed by the gitflow cycle rather than by commit
+    messages.
+
+    Args:
+        cz_ctx: commitizen context
+        start_rev: the revision *before* the range (exclusive), or None to scan
+            from the beginning of history.
+        end_rev: the last revision in the range (inclusive).
+        path: if given, only commits that touched this path are considered. This
+            provides per-project attribution: a breaking change to one project
+            does not escalate another.
+    """
+    from commitizen import git as cz_git
+    from commitizen.bump import find_increment
+    from commitizen.cz.conventional_commits import ConventionalCommitsCz
+
+    args = ""
+    if path is not None and str(path) not in (".", ""):
+        args = f"-- {path}"
+
+    commits = cz_git.get_commits(start=start_rev, end=end_rev, args=args)
+    if not commits:
+        return False
+
+    cz = ConventionalCommitsCz(cz_ctx.config)
+    # NOTE: bump_map (rather than bump_map_major_version_zero) is used so that a
+    # breaking change escalates to a major even during 0.x, consistent with the
+    # major_version_zero=False setting in _init_commitizen_context.
+    increment = find_increment(
+        commits, regex=cz.bump_pattern, increments_map=cz.bump_map
+    )
+    return increment == "MAJOR"
+
+
+def _find_nearest_major_version(
+    cz_ctx: CommitizenContext, promotion_rev: str | None
+) -> int:
+    """
+    Return the major version that the current prerelease cycle is based on.
+
+    This finds the highest version tag that existed before the current cycle,
+    bounded by the promotion marker (the same marker is_pending_minor_bump uses to
+    delimit the cycle). It excludes the cycle's own tags - including any major
+    the cycle has already produced - so a second breaking change does not
+    escalate again. A normal (non-breaking) cycle never changes the major, so
+    comparing the current version's major against this value tells us whether
+    the cycle has already escalated.
+    """
+    matcher = cz_ctx.provider._tag_format_matcher()
+    # Tags created during the current cycle (between the promotion marker and
+    # HEAD), the same set is_pending_minor_bump inspects. NOTE: get_tags can only
+    # *exclude* by ref (via end_rev / `git log --not`); its --tags traversal
+    # ignores start_rev, so we identify the cycle tags to subtract rather than
+    # trying to list the base tags directly.
+    cycle_tags = set(get_tags(end_rev=promotion_rev)) if promotion_rev else set()
+    versions = [
+        v
+        for tag in get_tags()
+        if tag not in cycle_tags and (v := matcher(tag)) is not None
+    ]
+    return max(versions).release[0] if versions else 0
+
+
+def is_pending_major_bump(
+    config: Config,
+    cz_ctx: CommitizenContext,
+    branch: str,
+    current_version: commitizen.version_schemes.VersionProtocol,
+    remote: str | None = None,
+    project_path: Path | str | None = None,
+) -> bool:
+    """
+    Return whether the current prerelease cycle should escalate to a new major.
+
+    This mirrors is_pending_minor_bump's once-per-cycle model: escalation happens only
+    on the most-experimental branch, only when a breaking change is present in
+    the cycle, and only if the cycle has not already escalated (guarding against
+    a second breaking change bumping the major a second time).
+    """
+    if branch != config.most_experimental_branch():
+        return False
+
+    promotion_rev = get_promotion_marker(remote)
+
+    if not has_breaking_change(cz_ctx, promotion_rev, "HEAD", project_path):
+        return False
+
+    base_major = _find_nearest_major_version(cz_ctx, promotion_rev)
+    # If the current version's major already exceeds the cycle's base major, the
+    # cycle has already escalated and we must not escalate again.
+    already_escalated = current_version.release[0] > base_major
+    if config.verbose and already_escalated:
+        click.echo(
+            f"Breaking change present but cycle already escalated to major "
+            f"{current_version.release[0]}",
+            err=True,
+        )
+    return not already_escalated
+
+
+def ensure_breaking_change_allowed(
+    config: Config,
+    branch: str,
+    project_name: str,
+    base_rev: str,
+    project_path: Path | str | None = None,
+    raise_error: bool = True,
+) -> None:
+    """
+    Guard against a breaking change appearing where it is not permitted.
+
+    Breaking changes are only allowed on the most-experimental branch, where they
+    escalate the major version. On any other branch a breaking change must not be
+    allowed to enter the hotfix cascade.
+
+    Args:
+        branch: the branch being tagged. Breaking changes are permitted on the
+            most-experimental branch; on any other branch this guard fires.
+        base_rev: the revision before the current push; the range base_rev..HEAD
+            is scanned for breaking changes.
+        raise_error: if True, raise a ClickException when a breaking change is
+            found (used by autotag). If False, emit a warning instead (used by
+            read-only queries like next-version).
+    """
+    exp_branch = config.most_experimental_branch()
+    if exp_branch is None or branch == exp_branch:
+        return
+
+    cz_ctx = _init_commitizen_context(config, project_name)
+    if has_breaking_change(cz_ctx, base_rev, "HEAD", project_path):
+        msg = (
+            f"Breaking change detected on branch {branch!r} for project "
+            f"{project_name!r}. Breaking changes are only permitted on the "
+            f"most-experimental branch ({exp_branch!r})."
+        )
+        if raise_error:
+            raise click.ClickException(msg)
+        click.echo(f"Warning: {msg}", err=True)
+
+
 def get_current_version(config: Config, project_name: str, as_tag: bool = False) -> str:
     """
     Return the current version.
@@ -831,6 +982,7 @@ def get_next_version(
     remote: str | None = None,
     as_tag: bool = False,
     dry_run: bool = True,
+    project_path: Path | str | None = None,
 ) -> str | None:
     """
     Return the next version for a given branch based on the latest changes.
@@ -844,6 +996,9 @@ def get_next_version(
         dry_run: if False, simply return the version or tag.  If True,
             also add missing promote markers, and return None if a branch has
             not yet received its first seed promotion.
+        project_path: the folder containing the project, used to attribute
+            breaking changes to the correct project. If None, it is looked up
+            from the project name.
     Returns:
         The next version or tag to be created
     """
@@ -877,7 +1032,7 @@ def get_next_version(
         prerelease = None
 
     # Find the closest promotion note to the current branch
-    pending_bump = is_pending_bump(
+    pending_bump = is_pending_minor_bump(
         config,
         cz_ctx.provider,
         branch,
@@ -885,9 +1040,20 @@ def get_next_version(
         add_missing_promote_marker=not dry_run,
     )
 
+    # A breaking change escalates the cycle to the next major, taking precedence
+    # over the cycle-start minor bump. Like the minor bump, this only happens on
+    # the most-experimental branch and only once per cycle. The project's folder
+    # is used to attribute breaking changes to the correct project.
+    if project_path is None:
+        project_path = get_project_path(project_name)
+    if is_pending_major_bump(
+        config, cz_ctx, branch, current_version, remote, project_path
+    ):
+        increment: Increment = "MAJOR"
+        exact_increment = True
     # Only apply minor increment the most experimental branch
-    if pending_bump:
-        increment: Increment = "MINOR"
+    elif pending_bump:
+        increment = "MINOR"
         exact_increment = True
     else:
         increment = "PATCH"
@@ -953,6 +1119,14 @@ def get_projects() -> list[tuple[Path, str]]:
         if project_name is not None:
             results.append((pyproject.parent, project_name))
     return sorted(results)
+
+
+def get_project_path(project_name: str) -> Path | None:
+    """Return the folder for the project with the given name, or None if unknown."""
+    for path, name in get_projects():
+        if name == project_name:
+            return path
+    return None
 
 
 def get_modified_projects(

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -172,6 +172,122 @@ class GitlabData:
         """https git url"""
         return self.project.http_url_to_repo
 
+    @staticmethod
+    def wait_for_job(
+        gitlab_project: gitlab.v4.objects.Project,
+        gitlab_job: gitlab.v4.objects.ProjectJob,
+    ):
+        """
+        Wait for the given job to complete
+
+        Args:
+            gitlab_project: Project object from the gitlab python API
+            gitlab_job: ProjectJob object from the gitlab python API
+        """
+        tries = 40
+        while tries:
+            print(f"{gitlab_job.name} status: {gitlab_job.status}")
+            if gitlab_job.status == "success":
+                return
+            elif gitlab_job.status in ["failed", "skipped"]:
+                gitlab_job.pprint()
+                raise RuntimeError(f"Job {gitlab_job.status}")
+            time.sleep(5.0)
+            gitlab_job = gitlab_project.jobs.get(gitlab_job.id)
+            tries -= 1
+        gitlab_job.pprint()
+        raise RuntimeError("Job failed to complete")
+
+    @staticmethod
+    def find_pipeline_job(
+        gitlab_project: gitlab.v4.objects.Project,
+        job_name_pattern: re.Pattern,
+        rev: str | None = None,
+        source: str | None = None,
+        updated_after: datetime | None = None,
+    ) -> gitlab.v4.objects.ProjectJob:
+        """
+        Return a Gitlab job matching the given search parameters.
+
+        Args:
+            gitlab_project: Project object from the gitlab python API
+            job_name_pattern: look for jobs whose name matches this regex
+            rev: look for jobs running on the given git revision
+            source: look for jobs triggered by this source event
+            updated_after: look for jobs created or modified after this time
+        """
+        tries = 20
+        while tries:
+            print(
+                f"Searching for active pipeline ({source=}, {rev=}) with {job_name_pattern=}"
+            )
+            # FIXME: it appears that this can deadlock here.
+            pipelines = gitlab_project.pipelines.list(
+                get_all=True, source=source, updated_after=updated_after
+            )
+            non_match = defaultdict(list)
+            for pipeline in pipelines:
+                if pipeline.status in ["success", "failed", "skipped"]:
+                    non_match["status"].append((pipeline.id, pipeline.status))
+                    continue
+                if rev and pipeline.sha != rev:
+                    non_match["rev"].append((pipeline.id, pipeline.rev))
+                    continue
+
+                jobs = pipeline.jobs.list(get_all=True)
+                for job in jobs:
+                    if job_name_pattern.match(job.name):
+                        return job
+                non_match["job_name"].append((pipeline.id, [job.name for job in jobs]))
+            print("Misses")
+            pprint.pprint(dict(non_match))
+            time.sleep(5.0)
+            tries -= 1
+        raise RuntimeError(
+            f"Failed to find {source} job matching {job_name_pattern} for {rev}"
+        )
+
+    @staticmethod
+    def gitlab_ci_local(job_name: str, runner_env: dict[str, str]):
+        options = []
+        remote_path = runner_env["CI_REPOSITORY_URL"]
+        options.extend(["--volume", f"{remote_path}:{remote_path}"])
+        for varname, value in runner_env.items():
+            options.extend(["--variable", f"{varname}={value}"])
+        print(options)
+        subprocess.run(["gitlab-ci-local", job_name] + options, check=True)
+
+    @staticmethod
+    def get_runner_env(
+        config: Config,
+        remote_url: str,
+        latest_commit: str,
+        base_rev: str | None,
+        branch: str,
+    ) -> dict[str, str]:
+        """Return environment variables that would be present on a Gitlab runner"""
+        if not base_rev:
+            try:
+                base_rev = git("rev-parse", "HEAD^", capture=True)
+            except subprocess.CalledProcessError:
+                base_rev = "0000000000000000000000000000000000000000"
+
+        title = git("log", "--pretty=format:%s", "-n1", capture=True)
+        return {
+            "CI_REPOSITORY_URL": remote_url,
+            "CI_PIPELINE_SOURCE": "push",
+            "CI_COMMIT_SHA": latest_commit,
+            "CI_COMMIT_BEFORE_SHA": base_rev,
+            "CI_COMMIT_BRANCH": branch,
+            "CI_COMMIT_TITLE": title,
+            "ACCESS_TOKEN": ACCESS_TOKEN,
+            "GITLAB_USER_EMAIL": "foo@bar.com",
+            "GITLAB_USER_NAME": "fakeuser",
+            "CI_COMMIT_REF_PROTECTED": "true",
+            "CI_DEFAULT_BRANCH": config.most_experimental_branch() or config.stable,
+            "GITLAB_CI": "false",
+        }
+
 
 @dataclasses.dataclass
 class LocalData:
@@ -184,7 +300,7 @@ class LocalData:
 
 @pytest.fixture
 def setup_git_repo(
-    tmpdir, gitlab_project, request
+    tmpdir, gitlab_project: gitlab.v4.objects.Project, request
 ) -> Generator[tuple[str, Config], None, None]:
     """
     Pytest fixture that sets up a temporary Git repository with an initial commit of project files.
@@ -363,27 +479,12 @@ def commit_file_and_push(
     git("push", "-f")
 
 
-def configure_environment(key: str, value: str, monkeypatch) -> None:
-    """
-    Configure an environment variable.
-
-    Args:
-        key (str): The environment variable key.
-        value (str): The environment variable value.
-        monkeypatch: The pytest monkeypatch fixture for setting environment variables.
-
-    Returns:
-        None
-    """
-    monkeypatch.setenv(key, value)
-
-
 def get_tags_with_annotations() -> list[str]:
     """
     Retrieve a chronological list of tags from the Git repository, formatted with their annotations.
 
     Note that chronological order is not reliable due to the fact that jobs run in
-    parallel in Gitlab.
+    parallel in GitlabData.
 
     Returns:
         A list of strings containing tags and their annotations.
@@ -435,80 +536,6 @@ def verify_git_graph(expected_graph: str) -> None:
     assert result == expected, f"Expected graph:\n{expected}\nActual graph:\n{result}"
 
 
-def find_pipeline_job(
-    gitlab_project: gitlab.v4.objects.Project,
-    job_name_pattern: re.Pattern,
-    rev: str | None = None,
-    source: str | None = None,
-    updated_after: datetime | None = None,
-) -> gitlab.v4.objects.ProjectJob:
-    """
-    Return a Gitlab job matching the given search parameters.
-
-    Args:
-        gitlab_project: Project object from the gitlab python API
-        job_name_pattern: look for jobs whose name matches this regex
-        rev: look for jobs running on the given git revision
-        source: look for jobs triggered by this source event
-        updated_after: look for jobs created or modified after this time
-    """
-    tries = 20
-    while tries:
-        print(
-            f"Searching for active pipeline ({source=}, {rev=}) with {job_name_pattern=}"
-        )
-        # FIXME: it appears that this can deadlock here.
-        pipelines = gitlab_project.pipelines.list(
-            get_all=True, source=source, updated_after=updated_after
-        )
-        non_match = defaultdict(list)
-        for pipeline in pipelines:
-            if pipeline.status in ["success", "failed", "skipped"]:
-                non_match["status"].append((pipeline.id, pipeline.status))
-                continue
-            if rev and pipeline.sha != rev:
-                non_match["rev"].append((pipeline.id, pipeline.rev))
-                continue
-
-            jobs = pipeline.jobs.list(get_all=True)
-            for job in jobs:
-                if job_name_pattern.match(job.name):
-                    return job
-            non_match["job_name"].append((pipeline.id, [job.name for job in jobs]))
-        print("Misses")
-        pprint.pprint(dict(non_match))
-        time.sleep(5.0)
-        tries -= 1
-    raise RuntimeError(
-        f"Failed to find {source} job matching {job_name_pattern} for {rev}"
-    )
-
-
-def wait_for_job(
-    gitlab_project: gitlab.v4.objects.Project, gitlab_job: gitlab.v4.objects.ProjectJob
-):
-    """
-    Wait for the given job to complete
-
-    Args:
-        gitlab_project: Project object from the gitlab python API
-        gitlab_job: ProjectJob object from the gitlab python API
-    """
-    tries = 40
-    while tries:
-        print(f"{gitlab_job.name} status: {gitlab_job.status}")
-        if gitlab_job.status == "success":
-            return
-        elif gitlab_job.status in ["failed", "skipped"]:
-            gitlab_job.pprint()
-            raise RuntimeError(f"Job {gitlab_job.status}")
-        time.sleep(5.0)
-        gitlab_job = gitlab_project.jobs.get(gitlab_job.id)
-        tries -= 1
-    gitlab_job.pprint()
-    raise RuntimeError("Job failed to complete")
-
-
 @overload
 def _tide(*args: str, capture: Literal[True]) -> str:
     pass
@@ -542,16 +569,6 @@ def get_version_at_ref(path: str, ref: str) -> str:
     return _tide("version", "--path", path, "--at-ref", ref, capture=True)
 
 
-def gitlab_ci_local(job_name: str, runner_env: dict[str, str]):
-    options = []
-    remote_path = runner_env["CI_REPOSITORY_URL"]
-    options.extend(["--volume", f"{remote_path}:{remote_path}"])
-    for varname, value in runner_env.items():
-        options.extend(["--variable", f"{varname}={value}"])
-    print(options)
-    subprocess.run(["gitlab-ci-local", job_name] + options, check=True)
-
-
 def run_autotag(
     runner_env,
     remote_data: GitlabData | LocalData,
@@ -576,7 +593,7 @@ def run_autotag(
 
     print(f"Running autotag: {annotation=}, {base_rev=}")
     if isinstance(remote_data, GitlabData):
-        job = find_pipeline_job(
+        job = remote_data.find_pipeline_job(
             remote_data.project,
             re.compile(r"^auto-tag$"),
             source="push",
@@ -585,14 +602,14 @@ def run_autotag(
             ),
         )
         if wait:
-            wait_for_job(remote_data.project, job)
+            remote_data.wait_for_job(remote_data.project, job)
         print("autotag job done")
         return job
     else:
         if EXEC_MODE == "gitlab-ci-local":
             # FIXME: use the push-opts file created by backend.push() to more accurately
             #  simulate the flow of variables between jobs
-            gitlab_ci_local(
+            GitlabData.gitlab_ci_local(
                 "auto-tag",
                 runner_env | {f"{ENVVAR_PREFIX}_AUTOTAG_ANNOTATION": annotation},
             )
@@ -629,18 +646,18 @@ def run_promote(
             schedule.play()
         else:
             raise RuntimeError("Could not find Promote schedule")
-        job = find_pipeline_job(
+        job = remote_data.find_pipeline_job(
             remote_data.project,
             re.compile("^promote$"),
             source="schedule",
             updated_after=datetime.fromisoformat(remote_data.project.updated_at),
         )
-        wait_for_job(remote_data.project, job)
+        remote_data.wait_for_job(remote_data.project, job)
         print("promote job done")
         return None
-    else:
+    else:  # LocalData
         if EXEC_MODE == "gitlab-ci-local":
-            gitlab_ci_local("promote", runner_env)
+            GitlabData.gitlab_ci_local("promote", runner_env)
         else:
             time.sleep(DELAY)
             _tide("promote")
@@ -667,54 +684,24 @@ def run_hotfix(runner_env, remote_data: GitlabData | LocalData) -> None:
     """
     job_name = "hotfix"
     if isinstance(remote_data, GitlabData):
-        job = find_pipeline_job(
+        job = remote_data.find_pipeline_job(
             remote_data.project,
             re.compile(f"^{job_name}$"),
             source="push",
             updated_after=datetime.fromisoformat(remote_data.project.updated_at),
         )
-        wait_for_job(remote_data.project, job)
-    else:
+        remote_data.wait_for_job(remote_data.project, job)
+    else:  # LocalData
         if EXEC_MODE == "gitlab-ci-local":
-            gitlab_ci_local(job_name, runner_env)
+            GitlabData.gitlab_ci_local(job_name, runner_env)
         else:
             time.sleep(DELAY)
             _tide("hotfix")
 
 
-def get_runner_env(
-    config: Config,
-    remote_url: str,
-    latest_commit: str,
-    base_rev: str | None,
-    branch: str,
-) -> dict[str, str]:
-    if not base_rev:
-        try:
-            base_rev = git("rev-parse", "HEAD^", capture=True)
-        except subprocess.CalledProcessError:
-            base_rev = "0000000000000000000000000000000000000000"
-
-    title = git("log", "--pretty=format:%s", "-n1", capture=True)
-    return {
-        "CI_REPOSITORY_URL": remote_url,
-        "CI_PIPELINE_SOURCE": "push",
-        "CI_COMMIT_SHA": latest_commit,
-        "CI_COMMIT_BEFORE_SHA": base_rev,
-        "CI_COMMIT_BRANCH": branch,
-        "CI_COMMIT_TITLE": title,
-        "ACCESS_TOKEN": ACCESS_TOKEN,
-        "GITLAB_USER_EMAIL": "foo@bar.com",
-        "GITLAB_USER_NAME": "fakeuser",
-        "CI_COMMIT_REF_PROTECTED": "true",
-        "CI_DEFAULT_BRANCH": config.most_experimental_branch() or config.stable,
-        "GITLAB_CI": "false",
-    }
-
-
 def setup_runner_env(monkeypatch, env: dict[str, str]):
     for key, value in env.items():
-        configure_environment(key, value, monkeypatch)
+        monkeypatch.setenv(key, value)
 
 
 @dataclasses.dataclass
@@ -755,7 +742,7 @@ class Context:
 
         latest_commit = current_rev()
 
-        runner_env = get_runner_env(
+        runner_env = GitlabData.get_runner_env(
             self.config, self.remote_data.remote_url, latest_commit, base_rev, branch
         )
 
@@ -828,14 +815,16 @@ class Context:
         if isinstance(self.remote_data, GitlabData):
             print("Waiting for jobs: {}".format([job.name for job in jobs]))
             for job in jobs:
-                wait_for_job(self.remote_data.project, job)
+                self.remote_data.wait_for_job(self.remote_data.project, job)
             git("fetch", "--tags")
             git("fetch")
 
 
 @pytest.mark.unit
 def test_current_branch_in_ci_environment(config, monkeypatch):
-    runner_env = get_runner_env(config, "fakeurl", "fakecommit", "basebaserev", "beta")
+    runner_env = GitlabData.get_runner_env(
+        config, "fakeurl", "fakecommit", "basebaserev", "beta"
+    )
     setup_runner_env(monkeypatch, runner_env)
     assert GitlabRuntime(config).current_branch() == "beta"
 
@@ -844,7 +833,9 @@ def test_current_branch_in_ci_environment(config, monkeypatch):
 def test_get_remote_in_ci_environment(config, monkeypatch) -> None:
     url = "https://gitlab-ci-token:[MASKED]@gitlab.example.com/someproject/"
 
-    runner_env = get_runner_env(config, url, "fakecommit", "basebaserev", "beta")
+    runner_env = GitlabData.get_runner_env(
+        config, url, "fakecommit", "basebaserev", "beta"
+    )
     setup_runner_env(monkeypatch, runner_env)
     with patch("tide.core.git") as mock_git:
         mock_git.return_value = None
@@ -854,7 +845,9 @@ def test_get_remote_in_ci_environment(config, monkeypatch) -> None:
 
 @pytest.mark.unit
 def test_get_current_branch_in_ci_environment(config, monkeypatch) -> None:
-    runner_env = get_runner_env(config, "fakeurl", "fakecommit", "basebaserev", "beta")
+    runner_env = GitlabData.get_runner_env(
+        config, "fakeurl", "fakecommit", "basebaserev", "beta"
+    )
     setup_runner_env(monkeypatch, runner_env)
     assert GitlabRuntime(config).current_branch() == "beta"
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1330,3 +1330,112 @@ def test_dev_cycle_pre_promotion(setup_git_repo, monkeypatch, tmp_path_factory) 
     * initial state -  (tag: projectB-1.0.0, tag: projectA-1.0.0)
     """
     verify_git_graph(expected)
+
+
+@pytest.mark.unit
+def test_major_bump_on_breaking(setup_git_repo, monkeypatch, tmp_path_factory) -> None:
+    """
+    A breaking conventional commit on the most-experimental branch escalates the
+    current prerelease cycle to the next major version.
+
+    Verifies:
+    - a breaking commit escalates the cycle to the next major and resets the
+      prerelease counter (1.1.0b1 -> 2.0.0b0)
+    - the major is preserved on subsequent non-breaking commits (2.0.0b1)
+    - a second breaking commit within the same cycle does NOT escalate again
+      (no runaway to 3.0.0): it stays on the 2.x line (2.0.0b2)
+    - the major bump is scoped per-project: a second project that only receives
+      non-breaking changes stays on the 1.x line, even though the breaking
+      change to projectA took it to 2.x during the same cycle.
+    """
+    local_repo, config, remote_data = setup_git_repo
+    assert latest_tag("projectA-*") == "projectA-1.0.0"
+    assert latest_tag("projectB-*") == "projectB-1.0.0"
+
+    ctx = Context(config, remote_data, tmp_path_factory, monkeypatch)
+
+    # -- non-breaking feature starts the cycle (minor bump, as usual)
+    commit_file_and_push(
+        config.beta, "feat(projectA): add feature 1", folder="projectA"
+    )
+    with ctx.pipeline(config.beta, "(projectA) feature 1") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectA-*") == "projectA-1.1.0b0"
+
+    # -- projectB also starts its cycle with a non-breaking feature
+    commit_file_and_push(
+        config.beta, "feat(projectB): add feature 1", folder="projectB"
+    )
+    with ctx.pipeline(config.beta, "(projectB) feature 1") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectB-*") == "projectB-1.1.0b0"
+
+    # -- another non-breaking feature just advances the prerelease counter
+    commit_file_and_push(
+        config.beta, "feat(projectA): add feature 2", folder="projectA"
+    )
+    with ctx.pipeline(config.beta, "(projectA) feature 2") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectA-*") == "projectA-1.1.0b1"
+
+    # -- a breaking change escalates the cycle to the next major, resetting the
+    #    prerelease counter to b0
+    commit_file_and_push(
+        config.beta, "feat(projectA)!: drop the legacy config format", folder="projectA"
+    )
+    with ctx.pipeline(config.beta, "(projectA) breaking change") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectA-*") == "projectA-2.0.0b0"
+
+    # -- projectB's breaking-free change must NOT be escalated by projectA's
+    #    breaking change: it only advances the prerelease counter on the 1.x line
+    commit_file_and_push(
+        config.beta, "feat(projectB): add feature 2", folder="projectB"
+    )
+    with ctx.pipeline(config.beta, "(projectB) feature 2") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectB-*") == "projectB-1.1.0b1"
+
+    # -- a subsequent non-breaking commit preserves the major
+    commit_file_and_push(
+        config.beta, "fix(projectA): tidy up after the rename", folder="projectA"
+    )
+    with ctx.pipeline(config.beta, "(projectA) follow-up fix") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectA-*") == "projectA-2.0.0b1"
+
+    # -- a second breaking change in the same cycle must NOT escalate again
+    commit_file_and_push(
+        config.beta,
+        "feat(projectA)!: remove another deprecated call",
+        folder="projectA",
+    )
+    with ctx.pipeline(config.beta, "(projectA) second breaking change") as env:
+        run_autotag(env, remote_data)
+    assert latest_tag("projectA-*") == "projectA-2.0.0b2"
+
+    # projectA reached 2.x via breaking changes; projectB stayed on 1.x
+    assert latest_tag("projectA-*") == "projectA-2.0.0b2"
+    assert latest_tag("projectB-*") == "projectB-1.1.0b1"
+
+
+@pytest.mark.unit
+def test_breaking_change_rejected_on_hotfix_branch(
+    setup_git_repo, monkeypatch, tmp_path_factory
+) -> None:
+    """
+    Breaking changes are only permitted on the most-experimental branch. A
+    breaking commit on any other (hotfix) branch must cause autotag to error,
+    stopping it from entering the hotfix cascade.
+    """
+    local_repo, config, remote_data = setup_git_repo
+    assert latest_tag("projectA-*") == "projectA-1.0.0"
+
+    ctx = Context(config, remote_data, tmp_path_factory, monkeypatch)
+
+    commit_file_and_push(
+        config.stable, "feat(projectA)!: breaking change on stable", folder="projectA"
+    )
+    with ctx.pipeline(config.stable, "(projectA) breaking change on stable") as env:
+        with pytest.raises(subprocess.CalledProcessError):
+            run_autotag(env, remote_data)


### PR DESCRIPTION
- A breaking commit escalates only the project(s) whose files it touched.
- Breaking changes are only permitted on the most-experimental branch. On any other branch a breaking commit in the push makes `autotag` **error**
1be16b